### PR TITLE
fix(CIErrors): Fix TS Errors so CI can build

### DIFF
--- a/src/Component/DeveloppementProgress.tsx
+++ b/src/Component/DeveloppementProgress.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
     FaBolt,
     FaSearch,
@@ -16,7 +15,9 @@ const stageIcons = {
     Deploy: <FaRocket />
 };
 
-const stages = [
+type StageLabel = keyof typeof stageIcons;
+
+const stages: { id: number; label: StageLabel }[] = [
     { id: 1, label: "Initialization" },
     { id: 2, label: "Analysis" },
     { id: 3, label: "AI" },
@@ -24,7 +25,8 @@ const stages = [
     { id: 5, label: "Deploy" }
 ];
 
-export default function DevelopmentProgress({ currentStage }) {
+
+    export default function DevelopmentProgress({ currentStage }: { currentStage: number}) {
     return (
         <div className="progress-container">
             {stages.map((stage, index) => (

--- a/src/Component/SelectBar.tsx
+++ b/src/Component/SelectBar.tsx
@@ -1,7 +1,12 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import "./SelectBar.css";
 
-const fakeData = [
+type Repo = {
+    repo: string;
+    branches: string[];
+}
+
+const fakeData: Repo[] = [
     {
         repo: "frontend-app",
         branches: ["main", "feature/login", "bugfix/navbar"],
@@ -18,10 +23,10 @@ const fakeData = [
 
 export default function RepoBranchDropdown() {
     // State: repos user has added
-    const [addedRepos, setAddedRepos] = useState([]);
+    const [addedRepos, setAddedRepos] = useState<Repo[]>([]);
     const [showModal, setShowModal] = useState(false);
 
-    const handleSelect = (repo, branch) => {
+    const handleSelect = (repo: string, branch: string) => {
         alert(`Redirecting to: ${repo}/${branch}`);
         // For real navigation:
         // window.location.href = `/path/${repo}/${branch}`;
@@ -35,9 +40,9 @@ export default function RepoBranchDropdown() {
         setShowModal(false);
     };
 
-    const handleRepoAdd = (repo) => {
+    const handleRepoAdd = (repo: Repo) => {
         // Avoid duplicates
-        if (!addedRepos.find((r) => r.repo === repo.repo)) {
+        if (!addedRepos.find((r: Repo) => r.repo === repo.repo)) {
             setAddedRepos([...addedRepos, repo]);
         }
         setShowModal(false);
@@ -91,7 +96,7 @@ export default function RepoBranchDropdown() {
                                 key={repo.repo}
                                 className="repo-choice"
                                 onClick={() => handleRepoAdd(repo)}
-                                disabled={addedRepos.find((r) => r.repo === repo.repo)}
+                                disabled={!!addedRepos.find((r: Repo) => r.repo === repo.repo)}
                             >
                                 {repo.repo}
                             </button>

--- a/src/HomePageComponents/DeploymentSteps.tsx
+++ b/src/HomePageComponents/DeploymentSteps.tsx
@@ -68,7 +68,7 @@ export const DeploymentSteps: React.FC<DeploymentStepsProps> = ({
     }
   ];
 
-  const getStepStyles = (step: Step, index: number) => {
+  const getStepStyles = (step: Step) => {
     const baseStyles = "relative flex flex-col items-center text-center transition-all duration-500";
     
     switch (step.status) {
@@ -98,29 +98,17 @@ export const DeploymentSteps: React.FC<DeploymentStepsProps> = ({
     }
   };
 
-  const getConnectorStyles = (step: Step, nextStep?: Step) => {
-    if (!nextStep) return '';
-    
-    const isCompleted = step.status === 'completed';
-    const isActive = step.status === 'active' || nextStep.status === 'active';
-    
-    return `absolute top-6 left-1/2 w-full h-0.5 transition-all duration-500 ${
-      isCompleted ? 'bg-green-500' : 
-      isActive ? 'bg-blue-500' : 'bg-slate-600'
-    }`;
-  };
 
   return (
     <div className="max-w-4xl mx-auto mt-12 mb-8">
       <div className="relative">
         <div className="flex justify-between items-start">
-          {steps.map((step, index) => {
+          {steps.map((step) => {
             const StepIcon = step.icon;
-            const nextStep = steps[index + 1];
             
             return (
               <div key={step.id} className="flex-1 relative">
-                <div className={getStepStyles(step, index)}>
+                <div className={getStepStyles(step)}>
                   <div className={getIconStyles(step)}>
                     {step.status === 'completed' ? (
                       <CheckCircle className="w-6 h-6" />

--- a/src/HomePageComponents/StepItem.tsx
+++ b/src/HomePageComponents/StepItem.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import StepIcon from './StepIcon.tsx';
 import StepContent from './StepContent.tsx';
-import StepConnector from './StepConnector.tsx';
 
 interface Step {
   title: string;

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -175,19 +175,19 @@ class ApiService {
         return this.token;
     }
 
-    // Generic request method
     private async request<T>(
         url: string,
         options: RequestInit = {}
     ): Promise<ApiResponse<T>> {
         try {
-            const headers: HeadersInit = {
+            // Crée une instance Headers pour pouvoir utiliser .set()
+            const headers = new Headers({
                 'Content-Type': 'application/json',
                 ...options.headers,
-            };
+            });
 
             if (this.token) {
-                headers['Authorization'] = `Bearer ${this.token}`;
+                headers.set('Authorization', `Bearer ${this.token}`);
             }
 
             const controller = new AbortController();
@@ -221,6 +221,7 @@ class ApiService {
             };
         }
     }
+
 
     // SCANS endpoints
     async getScansSummary(user: string): Promise<ApiResponse<RepoSummary[]>> {
@@ -387,7 +388,6 @@ class ApiService {
         userId: string,
         repoUrl: string,
         branchId: string,
-        selectedRules: string[],
         useAI: boolean = false
     ): Promise<ApiResponse<ScanOut>> {
         const scanRequest: CreateScanRequest = {


### PR DESCRIPTION
This pull request introduces several improvements across multiple files, focusing on type safety enhancements, code simplifications, and minor refactorings. The changes improve maintainability and reduce potential runtime errors by leveraging TypeScript features and cleaning up unused code.

### Type Safety Enhancements:

* [`src/Component/DeveloppementProgress.tsx`](diffhunk://#diff-f7e6d81c7426aa3e461b1c54152f09f7ab7698f4f96e422b6270b72a60d94d93L19-R29): Added a `StageLabel` type for `stageIcons` and updated the `DevelopmentProgress` component to include explicit typing for the `currentStage` prop.
* [`src/Component/SelectBar.tsx`](diffhunk://#diff-ec8e9a9d5fb68fac668b6d4a624410fdf81d7ec57339c37bc3a79929058c024bL21-R29): Introduced a `Repo` type for the `fakeData` array and added type annotations for state variables and functions, such as `handleSelect` and `handleRepoAdd`. [[1]](diffhunk://#diff-ec8e9a9d5fb68fac668b6d4a624410fdf81d7ec57339c37bc3a79929058c024bL21-R29) [[2]](diffhunk://#diff-ec8e9a9d5fb68fac668b6d4a624410fdf81d7ec57339c37bc3a79929058c024bL38-R45) [[3]](diffhunk://#diff-ec8e9a9d5fb68fac668b6d4a624410fdf81d7ec57339c37bc3a79929058c024bL94-R99)

### Code Simplifications:

* [`src/HomePageComponents/DeploymentSteps.tsx`](diffhunk://#diff-cc51ee73fee81cd6584207926cc739bdcb91ba37129985d8cef6bf4777ae115bL71-R71): Removed the `index` parameter from `getStepStyles` and eliminated the `getConnectorStyles` function, simplifying the logic for rendering steps. [[1]](diffhunk://#diff-cc51ee73fee81cd6584207926cc739bdcb91ba37129985d8cef6bf4777ae115bL71-R71) [[2]](diffhunk://#diff-cc51ee73fee81cd6584207926cc739bdcb91ba37129985d8cef6bf4777ae115bL101-R111)
* [`src/HomePageComponents/StepItem.tsx`](diffhunk://#diff-62390695d0e1334abd6b8a6bd10ba1086f10f50fccd922afcc0f538a16c486b2L5): Removed the unused `StepConnector` import, cleaning up the file.

### Refactoring for Improved Maintainability:

* [`src/apiService.ts`](diffhunk://#diff-1baffa351a85d434eba1a85bb918ceced7e424ef707dbbb210211ddecdae5274L178-R190): Replaced the plain object used for headers with a `Headers` instance to utilize the `.set()` method for cleaner header manipulation. Removed the unused `selectedRules` parameter from the `createScan` method. [[1]](diffhunk://#diff-1baffa351a85d434eba1a85bb918ceced7e424ef707dbbb210211ddecdae5274L178-R190) [[2]](diffhunk://#diff-1baffa351a85d434eba1a85bb918ceced7e424ef707dbbb210211ddecdae5274L390)