### PR TITLE
fix(ProgressBar): Fix Responsive

### DIFF
--- a/src/Component/DevelopmentProgress.css
+++ b/src/Component/DevelopmentProgress.css
@@ -99,7 +99,6 @@
     align-items: flex-start;
     justify-content: center;
     gap: 1rem;
-    flex-wrap: wrap;
     padding: 2rem 1rem;
 }
 


### PR DESCRIPTION
This pull request makes a minor style adjustment to the `DevelopmentProgress` component. The change removes the `flex-wrap: wrap;` property from the container's CSS, which will prevent child elements from wrapping onto multiple lines.

* Removed `flex-wrap: wrap;` from the container in `src/Component/DevelopmentProgress.css`, so child elements will remain on a single line and not wrap.